### PR TITLE
Skip Reason added to the test report

### DIFF
--- a/reportng/src/java/main/org/uncommons/reportng/ReportNGUtils.java
+++ b/reportng/src/java/main/org/uncommons/reportng/ReportNGUtils.java
@@ -31,6 +31,7 @@ import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.Reporter;
+import org.testng.SkipException;
 
 /**
  * Utility class that provides various helper methods that can be invoked
@@ -215,6 +216,26 @@ public class ReportNGUtils
     {
         String[] methods = result.getMethod().getMethodsDependedUpon();
         return commaSeparate(Arrays.asList(methods));
+    }
+    
+    
+    public boolean hasSkipException(ITestResult result) 
+    {
+    	return result.getThrowable() instanceof SkipException;
+    }
+    
+    
+    public String getSkipExceptionMessage(ITestResult result) 
+    {
+    	if (hasSkipException(result))
+    	{
+    		SkipException se = (SkipException) result.getThrowable();
+    		return se.getMessage();
+    	}
+    	else
+    	{
+    		return "";
+    	}
     }
 
 

--- a/reportng/src/java/resources/org/uncommons/reportng/messages/reportng.properties
+++ b/reportng/src/java/resources/org/uncommons/reportng/messages/reportng.properties
@@ -25,6 +25,7 @@ passed.tooltip=All tests passed.
 passedTests=Passed Tests
 passRate=Pass Rate
 skipped=Skipped
+skipped.reason=Reason
 skipped.tooltip=All executed tests passed but some tests were skipped.
 skippedConfiguration=Skipped Configuration
 skippedTests=Skipped Tests

--- a/reportng/src/java/resources/org/uncommons/reportng/messages/reportng_fr.properties
+++ b/reportng/src/java/resources/org/uncommons/reportng/messages/reportng_fr.properties
@@ -25,6 +25,7 @@ passed.tooltip=Tous les tests ont r&#x00E9;ussi.
 passedTests=Tests R&#x00E9;ussis
 passRate=Taux de R&#x00E9;ussite
 skipped=Ignor&#x00E9;
+skipped.reason=Raison
 skipped.tooltip=Quelques tests ont &#x00E9;t&#x00E9; ignor&#x00E9;es.
 skippedConfiguration=Configuration Ignor&#x00E9;e
 skippedTests=Tests Ignor&#x00E9;s

--- a/reportng/src/java/resources/org/uncommons/reportng/messages/reportng_pt.properties
+++ b/reportng/src/java/resources/org/uncommons/reportng/messages/reportng_pt.properties
@@ -25,6 +25,7 @@ passed.tooltip=Todos os testes passaram.
 passedTests=Testes com Sucesso
 passRate=Taxa de sucesso
 skipped=N&#x00E3;o executado
+skipped.reason=Raz&#x00E3;o
 skipped.tooltip=Todos os testes executados passaram, mas alguns n&#x00E3;o foram executados.
 skippedConfiguration=Configura&#x00E7;&#x00E3;o dos testes N&#x00E3;o Executados
 skippedTests=Testes n&#x00E3;o executados

--- a/reportng/src/java/resources/org/uncommons/reportng/templates/html/class-results.html.vm
+++ b/reportng/src/java/resources/org/uncommons/reportng/templates/html/class-results.html.vm
@@ -31,6 +31,10 @@
         <i>$messages.getString("dependsOnMethods"): </i>
         <span class="dependency">$utils.getDependentMethods($testResult)</span>
       #end
+      #if ($utils.hasSkipException($testResult))
+      	<i>$messages.getString("skipped.reason"): </i>
+      	<span class="dependency">$utils.getSkipExceptionMessage($testResult)</span>
+      #end
     #end
 
     #if ($utils.hasArguments($testResult))


### PR DESCRIPTION
When throwing a SkipException to programmatically skip a test you give it a message. I added functionality to print this message in the test report and updated the language properties files (based on google translate though, so this might need to be verified).
