### PR TITLE
Allow optional suppression of successful tests in reportng

### DIFF
--- a/reportng/src/java/main/org/uncommons/reportng/HTMLReporter.java
+++ b/reportng/src/java/main/org/uncommons/reportng/HTMLReporter.java
@@ -182,9 +182,10 @@ public class HTMLReporter extends AbstractReporter
             int index2 = 1;
             for (ISuiteResult result : suite.getResults().values())
             {
-                if (onlyShowFailures && result.getTestContext().getFailedTests().size() == 0)
+                boolean failuresExist = ((result.getTestContext().getFailedTests().size() > 0) || (result.getTestContext().getFailedConfigurations().size() > 0));
+                if (onlyShowFailures && !failuresExist)
                 {
-                    //onlyShowFailures is true and this result doesn't have any failures, so skip file creation
+                    //onlyShowFailures is true and this result doesn't have any failed tests or configurations, so skip file creation
                     ++index2; //increment the suite number because the velocity template will
                     continue;
                 }

--- a/reportng/src/java/resources/org/uncommons/reportng/templates/html/overview.html.vm
+++ b/reportng/src/java/resources/org/uncommons/reportng/templates/html/overview.html.vm
@@ -63,8 +63,9 @@
   #set ($totalPassed = $totalPassed + $result.testContext.passedTests.size())
   #set ($totalSkipped = $totalSkipped + $result.testContext.skippedTests.size())
   #set ($totalFailed = $totalFailed + $result.testContext.failedTests.size())
+  #set ($failuresExist = $result.testContext.failedTests.size()>0 || $result.testContext.failedConfigurations.size()>0)
 
-  #if (($onlyreportfailures && $result.testContext.failedTests.size() > 0) || ( !$onlyreportfailures))
+  #if (($onlyreportfailures && $failuresExist) || (!$onlyreportfailures))
   <tr class="test">
     <td class="test">
       <a href="suite${suiteId}_test${velocityCount}_results.html">${result.testContext.name}</a>

--- a/reportng/src/java/resources/org/uncommons/reportng/templates/html/suites.html.vm
+++ b/reportng/src/java/resources/org/uncommons/reportng/templates/html/suites.html.vm
@@ -38,7 +38,9 @@
   <tbody id="tests-${velocityCount}" class="tests">
     #set ($suiteId = $velocityCount)
     #foreach ($result in $suite.results)
-        #if (($onlyreportfailures && $result.testContext.failedTests.size() > 0) || ( !$onlyreportfailures))
+        #set ($failuresExist = $result.testContext.failedTests.size()>0 || $result.testContext.failedConfigurations.size()>0)
+
+        #if (($onlyreportfailures && $failuresExist) || (!$onlyreportfailures))
         <tr>
       <td class="test">
         #if ($result.testContext.failedTests.size() > 0)


### PR DESCRIPTION
Hi,

I'm using testng on a pretty large testbed (over 10k tests) and really like using ReportNG to produce the reports. Since ReportNG includes all tests in the report, if only 1 test failed, it becomes a needle in a haystack type of task to find the failing test.

So i implemented an "onlyreportfailures" option that will only show failed tests and failed configurations in the report. 

I've been using it locally and it's working pretty well, any interest in putting into the official build?

thanks
